### PR TITLE
Support wallet ordering

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,9 +12,14 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python: ["3.8", "3.9", "3.10", "3.11", "3.12" ]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python }}
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,20 @@ on:
 permissions:
   contents: write
 jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt -r requirements-dev.txt
+      - name: Test with pytest
+        run: |
+          pytest
+
+
   deploy:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,4 +18,4 @@ jobs:
           pip install -r requirements.txt -r requirements-dev.txt
       - name: Test with pytest
         run: |
-           python -m pytest
+          python -m pytest --cov-report term-missing --cov=aiogram_tonconnect 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,13 +1,12 @@
 name: test
-on:
-  push:
+on: [push]
 
 jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: ["3.8", "3.9", "3.10", "3.11", "3.12" ]
+        python: ["3.9", "3.10", "3.11", "3.12" ]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,9 +1,7 @@
-name: ci 
+name: test
 on:
   push:
 
-permissions:
-  contents: write
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,4 +18,4 @@ jobs:
           pip install -r requirements.txt -r requirements-dev.txt
       - name: Test with pytest
         run: |
-          pytest
+           python -m pytest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,15 +1,29 @@
 name: ci 
 on:
   push:
-    branches:
-      - master 
-      - main
-    paths:
-      - 'docs/**'
 
 permissions:
   contents: write
 jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python: ["3.8", "3.9", "3.10", "3.11", "3.12" ]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt -r requirements-dev.txt
+      - name: Test with pytest
+        run: |
+          pytest
+
+
   deploy:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,25 +20,3 @@ jobs:
       - name: Test with pytest
         run: |
           pytest
-
-
-  deploy:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Configure Git Credentials
-        run: |
-          git config user.name github-actions[bot]
-          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
-      - uses: actions/setup-python@v4
-        with:
-          python-version: 3.x
-      - run: echo "cache_id=$(date --utc '+%V')" >> $GITHUB_ENV 
-      - uses: actions/cache@v3
-        with:
-          key: mkdocs-material-${{ env.cache_id }}
-          path: .cache
-          restore-keys: |
-            mkdocs-material-
-      - run: pip install mkdocs-material 
-      - run: mkdocs gh-deploy --force

--- a/aiogram_tonconnect/middleware.py
+++ b/aiogram_tonconnect/middleware.py
@@ -25,6 +25,7 @@ class AiogramTonConnectMiddleware(BaseMiddleware):
     :param manifest_url: URL to the AiogramTonConnect manifest.
     :param redirect_url: URL to the redirect after connecting.
     :param exclude_wallets: List of wallet names to exclude.
+    :param wallets_order: Preferred wallets order.
     :param qrcode_provider: QRImageProviderBase or QRUrlProviderBase instance.
         Available default classes:
         - QRImageProvider: Generates QR codes locally using the library and
@@ -44,11 +45,13 @@ class AiogramTonConnectMiddleware(BaseMiddleware):
             inline_keyboard: Optional[Type[InlineKeyboardBase]] = None,
             qrcode_provider: Optional[Union[QRImageProviderBase, QRUrlProviderBase]] = None,
             tonapi_token: Optional[str] = None,
+            wallets_order: Optional[List[str]] = None,
     ) -> None:
         self.storage = storage
         self.manifest_url = manifest_url
         self.redirect_url = redirect_url
         self.exclude_wallets = exclude_wallets
+        self.wallets_order = wallets_order
 
         self.qrcode_provider = qrcode_provider or QRImageProvider()
         self.text_message = text_message or TextMessage
@@ -108,6 +111,7 @@ class AiogramTonConnectMiddleware(BaseMiddleware):
                 manifest_url=self.manifest_url,
                 redirect_url=self.redirect_url,
                 exclude_wallets=self.exclude_wallets,
+                wallets_order=self.wallets_order,
                 tonapi_token=self.tonapi_token,
             )
             atc_manager = ATCManager(

--- a/aiogram_tonconnect/tonconnect/tonconnect.py
+++ b/aiogram_tonconnect/tonconnect/tonconnect.py
@@ -17,6 +17,7 @@ class AiogramTonConnect(BaseTonConnect):
     :param manifest_url: URL to the manifest file.
     :param redirect_url: URL to the redirect after connecting.
     :param exclude_wallets: Optional list of wallet names to exclude.
+    :param wallets_order: Optional preferred wallets order.
     :param args: Additional positional arguments.
     :param kwargs: Additional keyword arguments.
     """
@@ -28,6 +29,7 @@ class AiogramTonConnect(BaseTonConnect):
             redirect_url: str = None,
             exclude_wallets: Optional[List[str]] = None,
             tonapi_token: Optional[str] = None,
+            wallets_order: Optional[List[str]] = None,
             *args,
             **kwargs,
     ) -> None:
@@ -35,7 +37,7 @@ class AiogramTonConnect(BaseTonConnect):
         kwargs["manifest_url"] = manifest_url
         super().__init__(*args, **kwargs)
         self.redirect_url = redirect_url
-        self.wallet_manager = WalletManager(exclude_wallets=exclude_wallets)
+        self.wallet_manager = WalletManager(exclude_wallets=exclude_wallets, wallets_order=wallets_order)
         self.tonapi_token = tonapi_token
 
     async def get_wallets(self=None) -> List[AppWallet]:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+pytest
+pytest-asyncio

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,3 @@
 pytest
+pytest-cov
 pytest-asyncio

--- a/test/test_wallet_manager.py
+++ b/test/test_wallet_manager.py
@@ -1,0 +1,19 @@
+
+import pytest
+
+from aiogram_tonconnect.tonconnect.wallet.manager import WalletManager
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('wallets_order, expected_wallets', [
+    ([], ['telegram-wallet', 'tonkeeper', 'mytonwallet', 'tonhub']),
+    (['mytonwallet', 'tonkeeper'], ['mytonwallet', 'tonkeeper', 'telegram-wallet', 'tonhub']),
+    (['tonhub'], ['tonhub', 'telegram-wallet', 'tonkeeper', 'mytonwallet']),
+])
+async def test_wallet_get_wallets(wallets_order, expected_wallets):
+    wm = WalletManager(wallets_order=wallets_order)
+    wallets = await wm.get_wallets()
+    wallet_names = [wallet.app_name for wallet in wallets]
+    assert wallet_names == expected_wallets
+
+


### PR DESCRIPTION
Hello! This PR introduces `wallets_order` parameter, it meant to allow users to configure wallets order for inline keyboard (example: lift tonkeeper up, because it's the most used wallet among users)

And also sprinkles some testing on top ✨✨