### PR TITLE
Fix handling users with null language code

### DIFF
--- a/aiogram_tonconnect/tonconnect/models.py
+++ b/aiogram_tonconnect/tonconnect/models.py
@@ -136,7 +136,7 @@ class ATCUser(BaseModel):
     """
 
     id: int
-    language_code: str
+    language_code: Optional[str] = Field(default=None)
     app_wallet: Optional[AppWallet] = Field(default=None)
     info_wallet: Optional[InfoWallet] = Field(default=None)
     account_wallet: Optional[AccountWallet] = Field(default=None)

--- a/test/test_middleware.py
+++ b/test/test_middleware.py
@@ -1,0 +1,29 @@
+from unittest.mock import MagicMock, AsyncMock
+
+import pytest
+
+from aiogram_tonconnect.middleware import AiogramTonConnectMiddleware
+
+
+@pytest.mark.asyncio
+async def test_user_with_null_language_code():
+    mock_storage = MagicMock()
+    middleware = AiogramTonConnectMiddleware(storage=mock_storage, manifest_url='https://example.com')
+    dummy_handler = AsyncMock()
+
+    class MockChat:
+        type = 'private'
+
+    class MockUser:
+        id = 123
+        is_bot = False
+        language_code = None
+
+    mock_state = AsyncMock()
+    mock_state.get_data = AsyncMock(return_value={})
+
+    await middleware(handler=dummy_handler, event=MagicMock(), data={
+        'state': mock_state,
+        'event_from_user': MockUser(),
+        'event_chat': MockChat(),
+    })

--- a/test/test_wallet_manager.py
+++ b/test/test_wallet_manager.py
@@ -14,6 +14,6 @@ async def test_wallet_get_wallets(wallets_order, expected_wallets):
     wm = WalletManager(wallets_order=wallets_order)
     wallets = await wm.get_wallets()
     wallet_names = [wallet.app_name for wallet in wallets]
-    assert wallet_names == expected_wallets
+    assert wallet_names[:len(expected_wallets)] == expected_wallets
 
 


### PR DESCRIPTION
Hello! Thanks for nice library!

In my project i've noticed that there are some users with null language_code and aiogram-tonconnect throws following exception:

```
ValidationError
1 validation error for ATCUser
language_code
  Input should be a valid string [type=string_type, input_value=None, input_type=NoneType]
    For further information visit https://errors.pydantic.dev/2.8/v/string_type
```

This happens because library expects that it will receive not null value. 

Additionally aiogram library declares that user language code can be null

https://docs.aiogram.dev/en/dev-3.x/api/types/user.html#aiogram.types.user.User.language_code