### PR TITLE
Fix tg wallet url

### DIFF
--- a/aiogram_tonconnect/tonconnect/provider.py
+++ b/aiogram_tonconnect/tonconnect/provider.py
@@ -174,7 +174,7 @@ class BridgeProvider(BaseBridgeProvider):
             listener(wallet_message)
 
     def _generate_tg_universal_url(self, universal_url: str, request: dict):
-        universal_url = universal_url.replace("attach=wallet", "startattach=")
+        universal_url = universal_url.replace("attach=wallet&mode=compact", "mode=compact&startattach=")
         link = self._generate_regular_universal_url('about:blank', request)
         link_params = link.split('?')[1]
 


### PR DESCRIPTION
The old url looks like 
`https://t.me/wallet?startattach=&mode=compacttonconnect-v__2-id__ ... -ret__back`
The fixed url looks like 
`https://t.me/wallet?mode=compact&startattach=tonconnect-v__2-id__ ... -ret__back`